### PR TITLE
cmd arg -d ne génére plus les secrets

### DIFF
--- a/dist/genk8smanifest-linux-arm64
+++ b/dist/genk8smanifest-linux-arm64
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58afb882535a69fa5a446fe14fb0c30cbc34e52cbfbcc97141c70b000194fdcf
-size 50535194
+oid sha256:570f1ffd584189e00eed2110428e8ef79fdab678221b183eaf41ac040662a682
+size 50536102

--- a/dist/genk8smanifest-linux-x64
+++ b/dist/genk8smanifest-linux-x64
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a96167bd3cb77ae77a33583d7795290d017e8832ba88bd2755280763f108eaed
-size 51779618
+oid sha256:8f7b4ff93be3a1b2de01b645a4513d07e98291ce6f1c2c8f235ceabc5cd03741
+size 51777746

--- a/dist/genk8smanifest-win-x64.exe
+++ b/dist/genk8smanifest-win-x64.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5c5291417cbc00d1d7be055c0a91e9e12cfd08686f5765d9806cda85fa48ceb4
-size 43993474
+oid sha256:439690c2b37ea38af687ea6503b2c2764d81f194801c9da4bdd2b27753f59f62
+size 43991315

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const mainLib = require("./lib/mainLib");
 const fs = require("fs");
 
 const productname = "GenK8sManifest [@mytinydc.com]";
-const version = "v0.1.0-beta.1";
+const version = "v0.1.0-beta.2";
 
 /**
  * sync main process

--- a/lib/genLib.js
+++ b/lib/genLib.js
@@ -47,12 +47,10 @@ module.exports = {
    */
   genSecrets: (document, cmdarguments) => {
     return new Promise(async (resolv, reject) => {
-      // also used with deployment => because deployment need fresh secrets
       if (
         !cmdarguments ||
         cmdarguments.generationoptions.length === 0 ||
-        cmdarguments.generationoptions.includes(ARGSECRETS) ||
-        cmdarguments.generationoptions.includes(ARGDEPLOYMENT)
+        cmdarguments.generationoptions.includes(ARGSECRETS)
       ) {
         let yamldocument = [];
         await module.exports

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genk8smanifest",
-  "version": "v0.1.0-beta.1",
+  "version": "v0.1.0-beta.2",
   "description": "génerateur de 'manifest' kubernetes à partir d'un fichier de description yaml",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
la cmd -d générait les deployments, mais si j'utilise l'API deployment de kubernetes et envoi le contenu, les secrets ne passent pas, normal